### PR TITLE
Remove unnecessary endpoints

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -15,7 +15,6 @@
     "async-props": "^0.3.2",
     "escape-html": "^1.0.3",
     "express": "^4.13.4",
-    "http-proxy-middleware": "^0.15.2",
     "isomorphic-fetch": "^2.2.1",
     "material-ui": "^0.15.4",
     "rc-color-picker": "^1.0.0",

--- a/react/server.jsx
+++ b/react/server.jsx
@@ -9,7 +9,6 @@ import { match, RouterContext } from 'react-router';
 import routes from './routes';
 import AsyncProps, { loadPropsOnServer } from 'async-props';
 import fetchJson from './util/fetch-json';
-import proxy from 'http-proxy-middleware';
 import Canvas from './components/Canvas';
 
 // for material-ui https://www.npmjs.com/package/material-ui
@@ -22,10 +21,6 @@ if (!apiBaseUrl) {
 }
 
 const app = express();
-
-app.use(express.static('public'));
-
-app.use('/api/*', proxy({ target: apiBaseUrl, changeOrigin: true }));
 
 app.get('/img/:id', (req, res) => {
   fetchJson(`${apiBaseUrl}/api/rooms/${req.params.id}`)


### PR DESCRIPTION
nginxが返すので/apiとstatic filesのハンドルをやめる
